### PR TITLE
fix: move engine status clearing out of setTimeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,16 +80,15 @@ server.patch('/engine', (req, res) => {
 
         const x = Math.round(distance / velocity);
 
+        delete state.velocity[id];
+        delete state.blocked[id];
+
         if (new Date().getMilliseconds() % 3 === 0) {
-            setTimeout(() => {
-                delete state.velocity[id];
-                delete state.blocked[id];
+            setTimeout(() => {                
                 res.header('Content-Type', 'application/json').status(500).send('Car has been stopped suddenly. It\'s engine was broken down.');
             }, Math.random() * x ^ 0);
         } else {
-            setTimeout(() => {
-                delete state.velocity[id];
-                delete state.blocked[id];
+            setTimeout(() => {                
                 res.header('Content-Type', 'application/json').status(200).send(JSON.stringify({ success: true }));
             }, x);
         }


### PR DESCRIPTION
В текущей реализации сервера после успешного `Start Car's Engine` для выполненного сразу за ним `Switch Car's Engine to Drive Mode` может возвращаться статус 404 из-за того что сервер очистил state двигателя, полученный в ходе `Start Car's Engine`.
Эта проблема отображена в [текущем ТЗ](https://github.com/rolling-scopes-school/tasks/tree/master/stage2/tasks/async-race#cross-check), но её часть, касающуюся 404 статуса можно решить изменением кода сервера.

> When you push the "start engine button" and then the "stop engine button" or the "start race button" and "reset race button" and repeating this operation again and again as a mad man sometimes you can see an error with the status codes "404" or "429". Officially it is not a bug.

Проблема связана с тем, что иногда между текущими `Start Car's Engine` и `Switch Car's Engine to Drive Mode` срабатывают setTimeout от устаревших более ранних запросов `Switch Car's Engine to Drive Mode`.
Чтобы её исправить достаточно вынести `delete state.velocity[id]; delete state.blocked[id];` из setTimeout.